### PR TITLE
Add conflictStyle setting

### DIFF
--- a/.gitconfig.d/shared.gitconfig
+++ b/.gitconfig.d/shared.gitconfig
@@ -6,6 +6,8 @@
 	editor=vim
 [push]
 	autoSetupRemote = true
+[merge]
+	conflictStyle = diff3
 [alias]
 	st = status
 	stat = status


### PR DESCRIPTION
mergeした時に、対象の2つのブランチの内容だけでなく、共通の親の内容も一緒に表示してくれるオプション

## References

> merge.conflictstyle=diff3だけではダメなんです？
> rebaseとmergeでdiffの向きが逆なのはわかりにくいなもは思います
> * https://twitter.com/qnighy/status/1633342280462655488?s=46&t=pXwyyjKl7zl3aRS6AvCLqQ


* https://scrapbox.io/mrsekut-p/merge.conflictstyle=diff3
* https://genkichi.hateblo.jp/entry/2019/03/18/214206